### PR TITLE
Added support to marshall single primitives

### DIFF
--- a/src/main/java/com/fasterxml/jackson/contrib/jsonpath/DefaultJsonUnmarshaller.java
+++ b/src/main/java/com/fasterxml/jackson/contrib/jsonpath/DefaultJsonUnmarshaller.java
@@ -212,7 +212,13 @@ public class DefaultJsonUnmarshaller implements JsonUnmarshaller {
 		final Type genericType = field.getGenericType();
 
 		if (fieldType.isPrimitive()) {
-			reflectionUtil.setField(resultObject, field, unmarshalledValue);
+			if(!fieldType.isArray() && unmarshalledValue instanceof Collection) {
+				Collection cuv = (Collection) unmarshalledValue;
+				Object c = cuv.iterator().next();
+				reflectionUtil.setField(resultObject, field, objectMapper.convertValue(c, fieldType));
+			} else {
+				reflectionUtil.setField(resultObject, field, unmarshalledValue);
+			}
 
 		} else if (genericType instanceof ParameterizedType) {
 			final Class<?>[] actualTypeArguments = reflectionUtil.geClassArgumentsFromGeneric(genericType);


### PR DESCRIPTION
This PR enables a JSON path syntax of `
$.totalCounters..[?(@.displayName == 'FILE: Number of bytes read')].value` to yield a scalar value instead of an array of values. This simplifies the serialization when annotating a POJO.