### PR TITLE
Use name when @JsonProperty is given without value

### DIFF
--- a/src/main/java/com/fasterxml/jackson/contrib/jsonpath/util/CandidateField.java
+++ b/src/main/java/com/fasterxml/jackson/contrib/jsonpath/util/CandidateField.java
@@ -91,7 +91,7 @@ public class CandidateField {
 		}
 
 		String jsonPath;
-		if (jsonPropertyAnnotation == null) {
+		if (jsonPropertyAnnotation == null || "".equals(jsonPropertyAnnotation.value())) {
 			jsonPath = field.getName();
 		} else {
 			jsonPath = jsonPropertyAnnotation.value();


### PR DESCRIPTION
I believe this aligns with Jackson's behaviour, which is to use the field name when the @JsonProperty annotation is used without a value.